### PR TITLE
Initial Central Brain dependencies, config and example

### DIFF
--- a/centralbrain/.helmignore
+++ b/centralbrain/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/centralbrain/Chart.yaml
+++ b/centralbrain/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: centralbrain
+description: Central Brain is the obserbavility component for the IOP
+type: application
+version: 0.0.1
+appVersion: 0.0.1
+dependencies:
+- name: prometheus
+  version: 11.2.2
+  repository: "https://kubernetes-charts.storage.googleapis.com"
+- name: grafana
+  version: 5.0.24
+  repository: "https://kubernetes-charts.storage.googleapis.com"

--- a/centralbrain/README.md
+++ b/centralbrain/README.md
@@ -1,0 +1,36 @@
+# Central-Brain
+
+## Examples:
+
+### Scrape metrics from iop-revad in Prometheus
+
+```console
+$ cat << EOF > scrape-metrics-from-revad.yaml
+iop:
+  revad:
+    configFiles:
+      revad.toml: |
+        [shared]
+        jwt_secret = "mysecret"
+
+        [http]
+        address = "0.0.0.0:20080"
+
+        # Enable monitoring services
+        [http.services.prometheus]
+
+centralbrain:
+  prometheus:
+    extraScrapeConfigs: |
+      - job_name: 'revad'
+        static_configs:
+          - targets:
+              - iop-revad:20080
+EOF
+
+$ helm upgrade iop sciencemesh/iop -f scrape-metrics-from-revad.yaml
+
+$ helm upgrade centralbrain sciencemesh/centralbrain -f scrape-metrics-from-revad.yaml
+```
+
+- [ ] TODO (@SamuAlfagme): Determine whether a sidecar for revad is required to reload config on upgrades.

--- a/centralbrain/values.yaml
+++ b/centralbrain/values.yaml
@@ -1,0 +1,25 @@
+prometheus:
+  alertmanager:
+    enabled: false
+  pushgateway:
+    enabled: false
+  server:
+    persistentVolume:
+      enabled: false
+
+grafana:
+  adminUser: admin
+  adminPassword: admin
+  # sidecar:
+  #   dashboards:
+  #     enabled: true
+  #     label: grafana_dashboard
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          url: http://centralbrain-prometheus-server
+          access: proxy
+          isDefault: true


### PR DESCRIPTION
- Minimal config for prometheus & grafana deployment:
  - Lightweight defaults for now: disabled alertmanager/pushgateway
  - Provision Prometheus datasource in Grafana
  - `centralbrain/README.md` with Prometheus scrape config for iop-revad

## 📸 Screenshot time:

| Prometheus | Grafana |
|-------------|---------|
| ![Screenshot_2020-05-20 Prometheus Expression Browser](https://user-images.githubusercontent.com/2644445/82466274-7d9c1200-9ac0-11ea-980b-6bb9852f1c2d.png) | ![Screenshot_2020-05-20 Loading Settings - Grafana](https://user-images.githubusercontent.com/2644445/82466287-7ffe6c00-9ac0-11ea-820a-f1ba16a80a37.png) |

This one closes https://github.com/sciencemesh/sciencemesh/issues/84 and closes https://github.com/sciencemesh/sciencemesh/issues/85
