### PR TITLE
IOP Ingress Resource on .Values.ingress.enabled

### DIFF
--- a/centralbrain/Chart.yaml
+++ b/centralbrain/Chart.yaml
@@ -2,12 +2,5 @@ apiVersion: v2
 name: centralbrain
 description: Central Brain is the obserbavility component for the IOP
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.0.1
-dependencies:
-- name: prometheus
-  version: 11.2.2
-  repository: "https://kubernetes-charts.storage.googleapis.com"
-- name: grafana
-  version: 5.0.24
-  repository: "https://kubernetes-charts.storage.googleapis.com"

--- a/centralbrain/requirements.yaml
+++ b/centralbrain/requirements.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- name: prometheus
+  version: 11.2.2
+  repository: "https://kubernetes-charts.storage.googleapis.com"
+- name: grafana
+  version: 5.0.24
+  repository: "https://kubernetes-charts.storage.googleapis.com"

--- a/iop/Chart.yaml
+++ b/iop/Chart.yaml
@@ -2,12 +2,8 @@ apiVersion: v2
 name: iop
 description: ScienceMesh IOP is the reference Federated Scientific Mesh platform
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.0.1
 icon: https://developer.sciencemesh.io/logo.svg
 home: https://developer.sciencemesh.io/
 source: https://github.com/sciencemesh/sciencemesh
-dependencies:
-- name: revad
-  version: "0.1.0"
-  repository: "https://cs3org.github.io/charts"

--- a/iop/requirements.yaml
+++ b/iop/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: revad
+  version: "0.1.2"
+  repository: "https://cs3org.github.io/charts"

--- a/iop/requirements.yaml
+++ b/iop/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: revad
-  version: "0.1.2"
+  version: "0.1.4"
   repository: "https://cs3org.github.io/charts"

--- a/iop/templates/_helpers.tpl
+++ b/iop/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "iop.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "iop.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "iop.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "iop.labels" -}}
+helm.sh/chart: {{ include "iop.chart" . }}
+{{ include "iop.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "iop.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "iop.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/iop/templates/ingress.yaml
+++ b/iop/templates/ingress.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "iop.fullname" . }}
+  labels: {{- include "iop.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.ingress.annotations }}
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+    {{- end }}
+spec:
+  rules:
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "iop.fullname" . }}-revad
+              servicePort: grpc
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end }}

--- a/iop/templates/ingress.yaml
+++ b/iop/templates/ingress.yaml
@@ -1,26 +1,29 @@
 {{- if .Values.ingress.enabled }}
+{{- range $service, $ingress := .Values.ingress.services }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "iop.fullname" . }}
-  labels: {{- include "iop.labels" . | nindent 4 }}
+  name: {{ template "iop.fullname" $ }}-{{ $service }}
+  labels: {{- include "iop.labels" $ | nindent 4 }}
   annotations:
-    {{- if .Values.ingress.annotations }}
-{{ toYaml .Values.ingress.annotations | indent 4 }}
+    {{- if $ingress.annotations }}
+{{ toYaml $ingress.annotations | indent 4 }}
     {{- end }}
 spec:
   rules:
-    {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    {{- if $ingress.hostname }}
+    - host: {{ $ingress.hostname }}
       http:
         paths:
-          - path: {{ .Values.ingress.path }}
+          - path: {{ $ingress.path }}
             backend:
-              serviceName: {{ template "iop.fullname" . }}-revad
-              servicePort: {{ .Values.ingress.servicePort }}
+              serviceName: {{ template "iop.fullname" $ }}-revad
+              servicePort: {{ $service }}
     {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if $ingress.tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
-  {{- end -}}
+{{ toYaml $ingress.tls | indent 4 }}
+  {{- end }}
+---
+{{- end }}
 {{- end }}

--- a/iop/templates/ingress.yaml
+++ b/iop/templates/ingress.yaml
@@ -14,10 +14,10 @@ spec:
     - host: {{ .Values.ingress.hostname }}
       http:
         paths:
-          - path: /
+          - path: {{ .Values.ingress.path }}
             backend:
               serviceName: {{ template "iop.fullname" . }}-revad
-              servicePort: grpc
+              servicePort: {{ .Values.ingress.servicePort }}
     {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/iop/values.yaml
+++ b/iop/values.yaml
@@ -1,9 +1,14 @@
 ingress:
   enabled: false
   hostname: iop.local
+  path: /
+  servicePort: http
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    #
+    # To expose the REVA grpc service pass servicePort: grpc
+    # as value with this annotation:
     # nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
   tls: []
     # Secrets must be present in the namespace beforehand.

--- a/iop/values.yaml
+++ b/iop/values.yaml
@@ -1,0 +1,12 @@
+ingress:
+  enabled: false
+  hostname: iop.local
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+  tls: []
+    # Secrets must be present in the namespace beforehand.
+    # - secretName: iop-tls
+    #   hosts:
+    #     - iop.local

--- a/iop/values.yaml
+++ b/iop/values.yaml
@@ -1,17 +1,27 @@
 ingress:
   enabled: false
-  hostname: iop.local
-  path: /
-  servicePort: http
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    #
-    # To expose the REVA grpc service pass servicePort: grpc
-    # as value with this annotation:
-    # nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-  tls: []
-    # Secrets must be present in the namespace beforehand.
-    # - secretName: iop-tls
-    #   hosts:
-    #     - iop.local
+  services:
+    http:
+      hostname: iop.local
+      path: /iop
+      # path: /iop(/|$)(.*)
+      annotations: {}
+        # kubernetes.io/ingress.class: nginx
+        # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        # nginx.ingress.kubernetes.io/rewrite-target: /$2
+      tls: []
+        # Secrets must be present in the namespace beforehand.
+        # - secretName: iop-tls
+        #   hosts:
+        #     - iop.local
+    grpc:
+      hostname: iop.local
+      path: /
+      annotations: {}
+        # kubernetes.io/ingress.class: nginx
+        # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        # nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      tls: []
+        # - secretName: iop-tls
+        #   hosts:
+        #     - iop.local


### PR DESCRIPTION
This aims to provide a generic ingress resource (not bound to a particular ingress controller) to expose the GRPC gateway in the revad deployment. 
- TLS certificates, if desired, must be provisioned in the cluster as a kubernetes TLS `Secret` resource beforehand.
- The Ingress controller of choice must be running for the resource to have the desired effect. 

I've also moved the `Chart.yaml` dependencies to it's own `dependencies.yaml` à la Helm2 to prevent nasty cross-compatibility issues (e.g. when using Flux' helm-operator do deploy)

- [x] Creating as draft PR so we can discuss whether to also expose the datagateway (HTTP) by default and how to proceed. 