### PR TITLE
Add wopiserver dependency and 'wopiserver.enabled' as feature flag to the IOP

### DIFF
--- a/iop/Chart.lock
+++ b/iop/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: revad
-  repository: https://cs3org.github.io/charts
-  version: 0.1.0
-digest: sha256:c6fb082f9525396e0bc2c1f2bbe107914d2e6bd120a035ae6ba34f4262a25994
-generated: "2020-04-22T15:32:32.187301+02:00"

--- a/iop/Chart.yaml
+++ b/iop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: iop
 description: ScienceMesh IOP is the reference Federated Scientific Mesh platform
 type: application
-version: 0.0.2
+version: 0.0.3
 appVersion: 0.0.1
 icon: https://developer.sciencemesh.io/logo.svg
 home: https://developer.sciencemesh.io/

--- a/iop/requirements.yaml
+++ b/iop/requirements.yaml
@@ -1,4 +1,8 @@
 dependencies:
 - name: revad
-  version: "0.1.4"
+  version: "0.1.6"
   repository: "https://cs3org.github.io/charts"
+- name: wopiserver
+  version: "0.1.0"
+  repository: "https://cs3org.github.io/charts"
+  condition: wopiserver.enabled

--- a/iop/values.yaml
+++ b/iop/values.yaml
@@ -25,3 +25,6 @@ ingress:
         # - secretName: iop-tls
         #   hosts:
         #     - iop.local
+
+wopiserver:
+  enabled: false


### PR DESCRIPTION
req. https://github.com/cs3org/charts/pull/10

- Remove stale Chart.lock (leftover from eb5880f)
- Bump revad chart to 0.1.6 (req. https://github.com/cs3org/charts/pull/12)