### PR TITLE
Add home/reva-storageProviders and rename original revad into 'gateway' for clarity

### DIFF
--- a/iop/Chart.yaml
+++ b/iop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: iop
 description: ScienceMesh IOP is the reference Federated Scientific Mesh platform
 type: application
-version: 0.0.3
+version: 0.1.0
 appVersion: 0.0.1
 icon: https://developer.sciencemesh.io/logo.svg
 home: https://developer.sciencemesh.io/

--- a/iop/requirements.yaml
+++ b/iop/requirements.yaml
@@ -1,7 +1,18 @@
 dependencies:
 - name: revad
-  version: "0.1.6"
+  version: "1.0.0"
   repository: "https://cs3org.github.io/charts"
+  alias: gateway
+- name: revad
+  version: "1.0.0"
+  repository: "https://cs3org.github.io/charts"
+  alias: storageprovider-home
+  condition: storageProviders.home.enabled
+- name: revad
+  version: "1.0.0"
+  repository: "https://cs3org.github.io/charts"
+  alias: storageprovider-reva
+  condition: storageProviders.reva.enabled
 - name: wopiserver
   version: "0.1.0"
   repository: "https://cs3org.github.io/charts"

--- a/iop/templates/ingress.yaml
+++ b/iop/templates/ingress.yaml
@@ -17,7 +17,7 @@ spec:
         paths:
           - path: {{ $ingress.path }}
             backend:
-              serviceName: {{ template "iop.fullname" $ }}-revad
+              serviceName: {{ template "iop.fullname" $ }}-gateway
               servicePort: {{ $service }}
     {{- end }}
   {{- if $ingress.tls }}

--- a/iop/values.yaml
+++ b/iop/values.yaml
@@ -26,5 +26,11 @@ ingress:
         #   hosts:
         #     - iop.local
 
+storageProviders:
+  home:
+    enabled: false
+  reva:
+    enabled: false
+
 wopiserver:
   enabled: false


### PR DESCRIPTION
This enables multiple REVA instances to play different roles in the cluster. Requires the `cs3org/revad` chart version `1.0.0`: https://github.com/cs3org/charts/pull/14

The new storage providers are independent and can be enabled with the value: '`storageProviders.{{ provider }}.enabled`':

```console
$ cat << EOF > custom-storage-providers.yaml
storageProviders:
  home:
    enabled: true
  reva:
    enabled: true

storageprovider-home:
  service:
    grpc:
      port: 17000
    http:
      port: 17001
  configFiles:
    revad.toml: |
      [grpc]
      address = "0.0.0.0:17000"

      [grpc.services.storageprovider]
      driver = "localhome"
      mount_path = "/home"
      mount_id = "123e4567-e89b-12d3-a456-426655440000"
      data_server_url = "http://localhost:17001/data"

      [http]
      address = "0.0.0.0:17001"

      [http.services.dataprovider]
      driver = "localhome"

storageprovider-reva:
  service:
    grpc:
      port: 18000
    http:
      port: 18001
  configFiles:
    revad.toml: |
      [grpc]
      address = "0.0.0.0:18000"

      [grpc.services.storageprovider]
      driver = "local"
      mount_path = "/reva"
      mount_id = "123e4567-e89b-12d3-a456-426655440000"
      data_server_url = "http://localhost:18001/data"

      [http]
      address = "0.0.0.0:18001"

      [http.services.dataprovider]
      driver = "local"
EOF

$ helm upgrade -i iop sciencemeshcharts/iop \
  [...] \                                # Pass the previous gateway cfg renaming the 'revad' keys to 'gateway'
  -f custom-storage-providers.yaml
```

And query the new resources (e.g. svc):

```console
$ kubectl get svc
NAME                       TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)               AGE
iop-gateway                ClusterIP   10.104.249.127   <none>        19001/TCP,19000/TCP   25h
iop-storageprovider-home   ClusterIP   10.109.142.17    <none>        17001/TCP,17000/TCP   25h
iop-storageprovider-reva   ClusterIP   10.104.249.246   <none>        18000/TCP             23h
```

**Note:** this is a breaking change with old user-provided values **due to the 's/revad/gateway/g' rename**. I'm bumping the Chart version to `0.1.0` to point at this fact. 

