### PR TITLE
Bumping external chart versions to use the latest ones

### DIFF
--- a/iop/Chart.yaml
+++ b/iop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: iop
 description: ScienceMesh IOP is the reference Federated Scientific Mesh platform
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.0.1
 icon: https://developer.sciencemesh.io/logo.svg
 home: https://developer.sciencemesh.io/

--- a/iop/requirements.yaml
+++ b/iop/requirements.yaml
@@ -1,19 +1,19 @@
 dependencies:
 - name: revad
-  version: "1.0.0"
+  version: "1.2.0"
   repository: "https://cs3org.github.io/charts"
   alias: gateway
 - name: revad
-  version: "1.0.0"
+  version: "1.2.0"
   repository: "https://cs3org.github.io/charts"
   alias: storageprovider-home
   condition: storageProviders.home.enabled
 - name: revad
-  version: "1.0.0"
+  version: "1.2.0"
   repository: "https://cs3org.github.io/charts"
   alias: storageprovider-reva
   condition: storageProviders.reva.enabled
 - name: wopiserver
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "https://cs3org.github.io/charts"
   condition: wopiserver.enabled


### PR DESCRIPTION
The ScienceMesh charts still use rather old versions of the Reva and WOPI server charts, so this PR bumps the version numbers to match the recent ones (i.e., 1.2.0 and 0.2.0, respectively).