### PR TITLE
Extend the 'enable' flag to the gateway for 'headless' storage providers

### DIFF
--- a/iop/Chart.yaml
+++ b/iop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: iop
 description: ScienceMesh IOP is the reference Federated Scientific Mesh platform
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.0.1
 icon: https://developer.sciencemesh.io/logo.svg
 home: https://developer.sciencemesh.io/

--- a/iop/requirements.yaml
+++ b/iop/requirements.yaml
@@ -3,16 +3,17 @@ dependencies:
   version: "1.2.0"
   repository: "https://cs3org.github.io/charts"
   alias: gateway
+  condition: gateway.enabled
 - name: revad
   version: "1.2.0"
   repository: "https://cs3org.github.io/charts"
   alias: storageprovider-home
-  condition: storageProviders.home.enabled
+  condition: storageprovider-home.enabled
 - name: revad
   version: "1.2.0"
   repository: "https://cs3org.github.io/charts"
   alias: storageprovider-reva
-  condition: storageProviders.reva.enabled
+  condition: storageprovider-reva.enabled
 - name: wopiserver
   version: "0.2.0"
   repository: "https://cs3org.github.io/charts"

--- a/iop/values.yaml
+++ b/iop/values.yaml
@@ -26,11 +26,14 @@ ingress:
         #   hosts:
         #     - iop.local
 
-storageProviders:
-  home:
-    enabled: false
-  reva:
-    enabled: false
+gateway:
+  enabled: true
+
+storageprovider-home:
+  enabled: false
+
+storageprovider-reva:
+  enabled: false
 
 wopiserver:
   enabled: false


### PR DESCRIPTION
Also, change the flag path for both `storageprovider-{home,reva}` to match their `alias` and remove some unnecessary multi-level block in `values.yaml`