### PR TITLE
fix ci/artifacthub lint

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -6,7 +6,8 @@ jobs:
   linter-artifacthub:
     runs-on: ubuntu-20.04
     container:
-      image: artifacthub/ah:v1.2.0
+      image: artifacthub/ah
+      options: --user root
     steps:
       - name: Checkout code
         uses: actions/checkout@master

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -6,7 +6,7 @@ jobs:
   linter-artifacthub:
     runs-on: ubuntu-20.04
     container:
-      image: artifacthub/ah
+      image: artifacthub/ah:v1.2.0
     steps:
       - name: Checkout code
         uses: actions/checkout@master


### PR DESCRIPTION
The latest artifacthub compatible with our lint workflow is v1.2.0