### PR TITLE
Apps config rehaul

### DIFF
--- a/iop/Chart.yaml
+++ b/iop/Chart.yaml
@@ -49,6 +49,13 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
+      description: Add app providers for Collabora and CodiMD and updated revad to support OCM
+      links:
+        - name: Apps config rehaul
+          url: https://github.com/sciencemesh/charts/pull/28
+        - name: Update revad to include OCM
+          url: https://github.com/cs3org/charts/pull/51
+    - kind: changed
       description: Update revad chart to support customconfigmaps and imagePullSecrets
       links:
         - name: Support for 'cfgmapName'

--- a/iop/Chart.yaml
+++ b/iop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: iop
 description: ScienceMesh IOP is the reference Federated Scientific Mesh platform
 type: application
-version: 0.3.1
+version: 0.4.0
 appVersion: 0.0.1
 icon: https://developer.sciencemesh.io/logo.svg
 home: https://developer.sciencemesh.io/
@@ -12,7 +12,6 @@ dependencies:
   version: "1.4.2"
   repository: "https://cs3org.github.io/charts"
   alias: gateway
-  condition: gateway.enabled
 - name: revad
   version: "1.4.2"
   repository: "https://cs3org.github.io/charts"
@@ -28,8 +27,18 @@ dependencies:
   repository: "https://cs3org.github.io/charts"
   alias: storageprovider-public
   condition: storageprovider-public.enabled
+- name: revad
+  version: "1.4.2"
+  repository: "https://cs3org.github.io/charts"
+  alias: appprovider-collabora
+  condition: appprovider-collabora.enabled
+- name: revad
+  version: "1.4.2"
+  repository: "https://cs3org.github.io/charts"
+  alias: appprovider-codimd
+  condition: appprovider-codimd.enabled
 - name: wopiserver
-  version: "0.5.2"
+  version: "0.9.0"
   repository: "https://cs3org.github.io/charts"
   condition: wopiserver.enabled
 maintainers:

--- a/iop/Chart.yaml
+++ b/iop/Chart.yaml
@@ -9,31 +9,31 @@ home: https://developer.sciencemesh.io/
 source: https://github.com/sciencemesh/sciencemesh
 dependencies:
 - name: revad
-  version: "1.6.0"
+  version: "1.6.1"
   repository: "https://cs3org.github.io/charts"
   alias: gateway
 - name: revad
-  version: "1.6.0"
+  version: "1.6.1"
   repository: "https://cs3org.github.io/charts"
   alias: storageprovider-home
   condition: storageprovider-home.enabled
 - name: revad
-  version: "1.6.0"
+  version: "1.6.1"
   repository: "https://cs3org.github.io/charts"
   alias: storageprovider-reva
   condition: storageprovider-reva.enabled
 - name: revad
-  version: "1.6.0"
+  version: "1.6.1"
   repository: "https://cs3org.github.io/charts"
   alias: storageprovider-public
   condition: storageprovider-public.enabled
 - name: revad
-  version: "1.6.0"
+  version: "1.6.1"
   repository: "https://cs3org.github.io/charts"
   alias: appprovider-collabora
   condition: appprovider-collabora.enabled
 - name: revad
-  version: "1.6.0"
+  version: "1.6.1"
   repository: "https://cs3org.github.io/charts"
   alias: appprovider-codimd
   condition: appprovider-codimd.enabled

--- a/iop/Chart.yaml
+++ b/iop/Chart.yaml
@@ -44,6 +44,8 @@ dependencies:
 maintainers:
   - name: SamuAlfageme
     email: samuel.alfageme.sainz@cern.ch
+  - name: glpatcern
+    email: Giuseppe.LoPresti@cern.ch
 annotations:
   artifacthub.io/changes: |
     - kind: changed

--- a/iop/Chart.yaml
+++ b/iop/Chart.yaml
@@ -9,31 +9,31 @@ home: https://developer.sciencemesh.io/
 source: https://github.com/sciencemesh/sciencemesh
 dependencies:
 - name: revad
-  version: "1.4.2"
+  version: "1.6.0"
   repository: "https://cs3org.github.io/charts"
   alias: gateway
 - name: revad
-  version: "1.4.2"
+  version: "1.6.0"
   repository: "https://cs3org.github.io/charts"
   alias: storageprovider-home
   condition: storageprovider-home.enabled
 - name: revad
-  version: "1.4.2"
+  version: "1.6.0"
   repository: "https://cs3org.github.io/charts"
   alias: storageprovider-reva
   condition: storageprovider-reva.enabled
 - name: revad
-  version: "1.4.2"
+  version: "1.6.0"
   repository: "https://cs3org.github.io/charts"
   alias: storageprovider-public
   condition: storageprovider-public.enabled
 - name: revad
-  version: "1.4.2"
+  version: "1.6.0"
   repository: "https://cs3org.github.io/charts"
   alias: appprovider-collabora
   condition: appprovider-collabora.enabled
 - name: revad
-  version: "1.4.2"
+  version: "1.6.0"
   repository: "https://cs3org.github.io/charts"
   alias: appprovider-codimd
   condition: appprovider-codimd.enabled

--- a/iop/ci/complete-iop-values.yaml
+++ b/iop/ci/complete-iop-values.yaml
@@ -29,6 +29,7 @@ gateway:
 
       [http.services.datagateway]
       [http.services.ocmd]
+      [http.services.ocmprovider]
       [http.services.ocdav]
       [http.services.ocs]
 
@@ -104,6 +105,12 @@ storageprovider-public:
 
       [grpc.services.authprovider.auth_managers.publicshares]
       gateway_addr = "iop-gateway:19000"
+
+appprovider-collabora:
+  enabled: true
+
+appprovider-codimd:
+  enabled: true
 
 wopiserver:
   enabled: true

--- a/iop/ci/complete-iop-values.yaml
+++ b/iop/ci/complete-iop-values.yaml
@@ -1,5 +1,4 @@
 gateway:
-  enabled: true
   configFiles:
     revad.toml: |
       [grpc.services.gateway]
@@ -108,3 +107,7 @@ storageprovider-public:
 
 wopiserver:
   enabled: true
+  config:
+    codimd:
+      enabled: true
+      inturl: http://meshapps-codimd

--- a/iop/templates/_helpers.tpl
+++ b/iop/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{/*
+Configure the wopiserver if apps are enabled
+*/}}
+{{ if or (index .Values "appprovider-codimd").enabled (index .Values "appprovider-collabora").enabled }}
+wopiserver:
+  enabled: true
+  config:
+    codimd:
+      enabled: {{ (index .Values "appprovider-codimd").enabled }}
+      inturl: http://meshapps-codimd
+{{ end }}

--- a/iop/templates/_helpers.tpl
+++ b/iop/templates/_helpers.tpl
@@ -9,3 +9,9 @@ wopiserver:
       enabled: {{ (index .Values "appprovider-codimd").enabled }}
       inturl: http://meshapps-codimd
 {{ end }}
+{{ if (index .Values "appprovider-codimd").enabled }}
+codimd:
+  codimd:
+    extraEnvironmentVariables:
+      CMD_DOMAIN: https://{{ .Values.ingress.hostname }}
+{{ end }}

--- a/iop/values.yaml
+++ b/iop/values.yaml
@@ -1,6 +1,3 @@
-gateway:
-  enabled: true
-
 storageprovider-home:
   enabled: false
 
@@ -10,5 +7,12 @@ storageprovider-reva:
 storageprovider-public:
   enabled: false
 
-wopiserver:
+# TODO not yet used
+shareprovider-ocm:
+  enabled: false
+
+appprovider-collabora:
+  enabled: false
+
+appprovider-codimd:
   enabled: false

--- a/meshapps/Chart.yaml
+++ b/meshapps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: meshapps
 description: Umbrella-repository of apps supported by the IOP and its adapters
 type: application
-version: 0.0.3
+version: 0.1.0
 appVersion: 0.0.1
 home: https://developer.sciencemesh.io/
 dependencies:

--- a/meshapps/README.md
+++ b/meshapps/README.md
@@ -1,15 +1,17 @@
 # MESHApps
 
-Colletion of apps supported by/compatible with the IOP and its adaptors.
+Collection of apps supported by the IOP and its adaptors.
+
+**Requirements:**
+- `iop` chart version >= `0.4.0`
+- `iop.wopiserver.enabled=true`
+- `wopiserver` chart version >= `0.9.0`
 
 ## [Collabora CODE](https://hub.helm.sh/charts/stable/collabora-code)
 
-- **Integration reference:** https://developer.sciencemesh.io/docs/technical-documentation/iop/deployment/kubernetes/wopiserver
-- **Requirements:** `iop.wopiserver.enabled=true` - `iop` chart version >= `0.0.3`
+- Integration reference: https://developer.sciencemesh.io/docs/technical-documentation/iop/deployment/kubernetes/wopiserver
 
 ## [CodiMD](https://hub.helm.sh/charts/codimd/codimd)
 
-- **Integration reference:** https://developer.sciencemesh.io/docs/technical-documentation/integrations/codimd
-- **Requirements:**
-  - `iop.wopiserver.enabled=true`
-  - `iop` chart version >= `0.1.1` (`wopiserver` chart >= `0.9.0`)
+- Integration reference: https://developer.sciencemesh.io/docs/technical-documentation/integrations/codimd
+

--- a/meshapps/README.md
+++ b/meshapps/README.md
@@ -11,5 +11,5 @@ Colletion of apps supported by/compatible with the IOP and its adaptors.
 
 - **Integration reference:** https://developer.sciencemesh.io/docs/technical-documentation/integrations/codimd
 - **Requirements:**
-  - `iop.wopiserver.enabled=true` and `iop.wopiserver.wopibridge.enabled=true`
-  - `iop` chart version >= `0.1.1` (`wopiserver` chart >= `0.2.0`)
+  - `iop.wopiserver.enabled=true`
+  - `iop` chart version >= `0.1.1` (`wopiserver` chart >= `0.9.0`)

--- a/meshapps/values.yaml
+++ b/meshapps/values.yaml
@@ -28,7 +28,6 @@ codimd:
       QT_QPA_PLATFORM:
       NODE_TLS_REJECT_UNAUTHORIZED: 0
       CMD_API_BODY_LIMIT: 210000
-      #CMD_DOMAIN: https://{{ .Values.ingress.hostname }}
       #CMD_URL_ADDPORT: true
       CMD_URL_PATH: codimd
       CMD_APPLIANCE_MODE: true

--- a/meshapps/values.yaml
+++ b/meshapps/values.yaml
@@ -28,7 +28,7 @@ codimd:
       QT_QPA_PLATFORM:
       NODE_TLS_REJECT_UNAUTHORIZED: 0
       CMD_API_BODY_LIMIT: 210000
-      #CMD_URL_ADDPORT: true
+      # CMD_URL_ADDPORT: true
       CMD_URL_PATH: codimd
       CMD_APPLIANCE_MODE: true
     versionCheck: false

--- a/meshapps/values.yaml
+++ b/meshapps/values.yaml
@@ -1,4 +1,4 @@
-collabora-code:
+collabora:
   enabled: false
   image:
     tag: latest
@@ -20,9 +20,18 @@ codimd:
       CMD_ALLOW_ANONYMOUS: true
       CMD_ALLOW_ANONYMOUS_EDITS: true
       CMD_ALLOW_ANONYMOUS_VIEWS: true
-      CMD_ALLOW_EMAIL_REGISTER: false
-      CMD_APPLIANCE_MODE: true
+      CMD_ALLOW_FREEURL: true
       CMD_EMAIL: false
+      CMD_ALLOW_EMAIL_REGISTER: false
+      CMD_ALLOW_GRAVATAR: true
+      CMD_ALLOW_PDF_EXPORT: true
+      QT_QPA_PLATFORM:
+      NODE_TLS_REJECT_UNAUTHORIZED: 0
+      CMD_API_BODY_LIMIT: 210000
+      #CMD_DOMAIN: https://{{ .Values.ingress.hostname }}
+      #CMD_URL_ADDPORT: true
+      CMD_URL_PATH: codimd
+      CMD_APPLIANCE_MODE: true
     versionCheck: false
     imageStorePersistentVolume:
       enabled: false


### PR DESCRIPTION
This PR includes
- Bare configuration for two more revad daemons, `revad-collabora` and `revad-codimd`
- Updated CodiMD configmap
- Updated WOPI server configuration and template, following https://github.com/cs3org/charts/pull/53 (needs to be merged first)
- Updated iop following https://github.com/cs3org/charts/pull/51

The revad configurations are rather empty, and in particular for the app providers one needs to follow:
https://developer.sciencemesh.io/docs/technical-documentation/iop/iop-optional-configs/collabora-wopi-server/wopiserver/

A future PR could include that in the charts.